### PR TITLE
feat: add support for Cursor MCP client

### DIFF
--- a/mcp_config_sync/apps.py
+++ b/mcp_config_sync/apps.py
@@ -43,6 +43,14 @@ MCP_APPS: Dict[str, MCPApp] = {
         description="Anthropic Claude Desktop application",
         homepage="https://claude.ai/",
     ),
+    "cursor": MCPApp(
+        name="cursor",
+        display_name="Cursor",
+        config_path="~/Library/Application Support/Cursor/User/settings.json",
+        description="AI-powered code editor with MCP support",
+        homepage="http://cursor.com",
+    ),
+  
 }
 
 


### PR DESCRIPTION
✅ Added client:
Cursor
Config path: ~/Library/Application Support/Cursor/User/settings.json (confirmed on macOS)
Homepage: https://cursor.com/
🔷 Notes:
Verified that Cursor creates a settings.json at the expected path on macOS.
The file currently does not include MCP-related settings by default, but this patch enables syncing MCP servers to it once users configure it.
🧪 Verification:
Ran mcp-config-sync --list-apps to confirm Cursor appears in the list of supported applications.